### PR TITLE
Additional csv endpoints

### DIFF
--- a/app/controllers/CSVController.scala
+++ b/app/controllers/CSVController.scala
@@ -1,0 +1,21 @@
+package controllers
+
+import java.io.File
+
+import play.api.mvc.{Action, Controller}
+import services.{Config, Dynamo}
+
+
+class CSVController extends Controller {
+
+  def generateCsvDownload() = Action {
+    Dynamo.getServiceCallsCsv()
+    Ok.sendFile(new File(s"${Config.homeDirectory}/export.csv"))
+  }
+
+  def generateCsvString() = Action {
+    val content = Dynamo.getServiceCallsCsv()
+    Ok(content)
+  }
+
+}

--- a/app/controllers/CSVController.scala
+++ b/app/controllers/CSVController.scala
@@ -1,12 +1,16 @@
 package controllers
 
 import java.io.File
+import javax.inject.Inject
 
+import models.ServiceCall
+import org.joda.time.format.DateTimeFormat
 import play.api.mvc.{Action, Controller}
-import services.{Config, Dynamo}
+import services.{Config, Dynamo, InUseService}
 
+class CSVController @Inject() (backend: InUseService) extends Controller {
 
-class CSVController extends Controller {
+  def millisToDate(ms: Long): String = DateTimeFormat.forPattern("yyyy-MM-dd").print(ms)
 
   def generateCsvDownload() = Action {
     Dynamo.getServiceCallsCsv()
@@ -16,6 +20,24 @@ class CSVController extends Controller {
   def generateCsvString() = Action {
     val content = Dynamo.getServiceCallsCsv()
     Ok(content)
+  }
+
+  def forService(service: String) = Action {
+
+    val serviceCalls: List[ServiceCall] = backend.getRecentServiceCallsMap().get(service) match {
+      case Some(calls) => calls
+      case None => List()
+    }
+
+    Ok("date,count\n" + serviceCalls
+      .groupBy(call => millisToDate(call.createdAt))  // group calls by date
+      .map({case (k, v) => (k, v.size)})              // convert to date->count map
+      .toList
+      .sortWith((p1, p2) => p1._1 < p2._1)            // sorted by date alpha
+      .map{ case (date, count) => s"$date,$count" }   // entries as strings
+      .mkString("\n")                                 // delimited by newlines
+    )
+
   }
 
 }

--- a/app/controllers/Management.scala
+++ b/app/controllers/Management.scala
@@ -1,9 +1,7 @@
 package controllers
 
-import java.io.File
-
 import play.api.mvc.{Action, Controller}
-import services.{Config, Dynamo}
+import services.Dynamo
 
 class Management extends Controller {
   def healthCheck = Action {
@@ -18,16 +16,6 @@ class Management extends Controller {
   def deleteSingleService(service: String) = Action {
     Dynamo.deleteSingleServiceAndAllCalls(service)
     Ok("Ok")
-  }
-
-  def generateCsvDownload() = Action {
-    Dynamo.getServiceCallsCsv()
-    Ok.sendFile(new File(s"${Config.homeDirectory}/export.csv"))
-  }
-
-  def generateCsvString() = Action {
-    val content = Dynamo.getServiceCallsCsv()
-    Ok(content)
   }
 
 }

--- a/app/services/InUseMemoryService.scala
+++ b/app/services/InUseMemoryService.scala
@@ -40,13 +40,16 @@ class InUseMemoryService extends InUseService {
 
   def getRecentServiceCallsMap(): Map[String, List[ServiceCall]] = calls
 
+  val today = DateTime.now.getMillis
+  val yesterday = DateTime.now.minusDays(1).getMillis
+
   // stub data
 
   registerService("example service")
   registerService("empty service")
   registerService("another service")
-  registerCall("example service", ServiceCall("example service", DateTime.now.getMillis, "mock data one"))
-  registerCall("example service", ServiceCall("example service", DateTime.now.getMillis, "mock data two"))
-  registerCall("example service", ServiceCall("example service", DateTime.now.getMillis, "mock data three"))
+  registerCall("example service", ServiceCall("example service", today, "mock data one"))
+  registerCall("example service", ServiceCall("example service", today, "mock data two"))
+  registerCall("example service", ServiceCall("example service", yesterday, "mock data three"))
 
 }

--- a/conf/routes
+++ b/conf/routes
@@ -10,6 +10,8 @@ POST /api/v1/services/:service controllers.APIController.addService(service: Str
 # add a new call against the service
 POST /api/v1/services/:service/records controllers.APIController.addRecord(service: String)
 
+GET /api/v1/servics/:service/records/csv controllers.CSVController.forService(service: String)
+
 # assets
 GET /assets/*file controllers.Assets.versioned(path="/public", file: Asset)
 
@@ -20,5 +22,6 @@ DELETE /api/v1/services/ controllers.Management.deleteAllHistory
 DELETE /api/v1/services/:service controllers.Management.deleteSingleService(service: String)
 
 # csv endpoints
+
 GET /csv controllers.CSVController.generateCsvDownload()
 GET /csv-view controllers.CSVController.generateCsvString()

--- a/conf/routes
+++ b/conf/routes
@@ -19,6 +19,6 @@ GET /management/healthcheck controllers.Management.healthCheck
 DELETE /api/v1/services/ controllers.Management.deleteAllHistory
 DELETE /api/v1/services/:service controllers.Management.deleteSingleService(service: String)
 
-# generate csv
-GET /csv controllers.Management.generateCsvDownload()
-GET /csv-view controllers.Management.generateCsvString()
+# csv endpoints
+GET /csv controllers.CSVController.generateCsvDownload()
+GET /csv-view controllers.CSVController.generateCsvString()

--- a/test/ApplicationSpec.scala
+++ b/test/ApplicationSpec.scala
@@ -1,9 +1,9 @@
-import controllers.IndexController
+import controllers.{CSVController, IndexController}
 import models.ServiceCall
 import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormat
 import org.scalatestplus.play._
 import play.api.test.FakeRequest
-import play.api.test._
 import play.api.test.Helpers._
 import services.{InUseMemoryService, InUseService}
 
@@ -71,6 +71,23 @@ class ApplicationSpec extends PlaySpec with OneAppPerTest {
       contentAsString(result) must include("three")
       contentAsString(result) mustNot include("one")
       contentAsString(result) mustNot include("two")
+
+    }
+
+    "Be able to CSV some calls" in {
+
+      val controller = new CSVController(new InUseMemoryService())
+      val result = controller.forService("example service")(FakeRequest())
+
+      val today = DateTime.now.getMillis
+      val yesterday = DateTime.now.minusDays(1).getMillis
+
+      def millisToDate(ms: Long): String = DateTimeFormat.forPattern("yyyy-MM-dd").print(ms)
+
+      status(result) mustBe OK
+
+      contentAsString(result) must include(millisToDate(today)+",2")
+      contentAsString(result) must include(millisToDate(yesterday)+",1")
 
     }
 


### PR DESCRIPTION
Had to do this manually, oh well

* adds a `service/<name>/records/csv route`